### PR TITLE
events: view participant promotions; menu choices

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -50,6 +50,17 @@ Hooks.DisplayConfetti = {
     window.scrollTo(0, document.body.scrollHeight);
   }
 }
+Hooks.ModalCheckboxHandlers = {
+  mounted() {
+    var checkbox = this.el;
+    this.handleEvent(
+      "js:modal:#" + checkbox.id,
+      function onModal(payload) {
+          checkbox.checked = payload.open;
+      },
+    );
+  }
+}
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}})

--- a/lib/trashy/events.ex
+++ b/lib/trashy/events.ex
@@ -66,16 +66,6 @@ defmodule Trashy.Events do
     )
   end
 
-  @doc """
-  Returns the list of events which a participant has attended, as a list of datetimes and cleanup_ids.
-
-  ## Examples
-
-      iex> list_events_for_participant(cleanup)
-      [%Event{}, ...]
-
-  """
-
   def get_total_participant_cleanup_count(participant) do
     query =
       from event_participant in EventParticipant,

--- a/lib/trashy/promotions/event_participant_promotion.ex
+++ b/lib/trashy/promotions/event_participant_promotion.ex
@@ -7,6 +7,7 @@ defmodule Trashy.Promotions.EventParticipantPromotion do
     # field :promotion_id, :id
     belongs_to(:promotion, Trashy.Promotions.Promotion)
     belongs_to(:event_participant, Trashy.Events.EventParticipant)
+    field(:choice, :string, default: "")
 
     timestamps()
   end
@@ -14,7 +15,12 @@ defmodule Trashy.Promotions.EventParticipantPromotion do
   @doc false
   def changeset(event_participant_promotion, attrs) do
     event_participant_promotion
-    |> cast(attrs, [:is_claimed, :promotion_id, :event_participant_id])
+    |> cast(attrs, [
+      :is_claimed,
+      :promotion_id,
+      :event_participant_id,
+      :choice
+    ])
     |> validate_required([:is_claimed, :promotion_id, :event_participant_id])
   end
 end

--- a/lib/trashy/promotions/promotion.ex
+++ b/lib/trashy/promotions/promotion.ex
@@ -8,14 +8,32 @@ defmodule Trashy.Promotions.Promotion do
     belongs_to(:cleanup, Trashy.Cleanups.Cleanup)
     field(:is_disabled, :boolean)
     field(:icon, :string)
+    field(:choices, {:array, :string}, default: [])
 
     timestamps()
   end
 
   @doc false
   def changeset(promotion, attrs) do
+    attrs = Map.replace(
+      attrs, "choices",
+      for s <- String.split(
+        attrs["choices"] || "",
+        "\n",   # Split line-by-line.
+        trim: true  # Ignore empty lines.
+      ) do
+        String.trim(s)  # Trim whitespace.
+      end
+    )
     promotion
-    |> cast(attrs, [:merchant, :details, :cleanup_id, :is_disabled, :icon])
+    |> cast(attrs, [
+      :merchant,
+      :details,
+      :cleanup_id,
+      :is_disabled,
+      :icon,
+      :choices,
+    ])
     |> validate_required([:merchant, :details, :cleanup_id])
   end
 end

--- a/lib/trashy/promotions/promotion.ex
+++ b/lib/trashy/promotions/promotion.ex
@@ -15,16 +15,11 @@ defmodule Trashy.Promotions.Promotion do
 
   @doc false
   def changeset(promotion, attrs) do
-    attrs = Map.replace(
-      attrs, "choices",
-      for s <- String.split(
-        attrs["choices"] || "",
-        "\n",   # Split line-by-line.
-        trim: true  # Ignore empty lines.
-      ) do
-        String.trim(s)  # Trim whitespace.
-      end
-    )
+    attrs = Map.update(attrs, "choices", [], fn val ->
+      (val || "")
+      |> String.split("\n", trim: true)
+      |> Enum.map(&String.trim/1)
+    end)
     promotion
     |> cast(attrs, [
       :merchant,

--- a/lib/trashy_web/controllers/event_controller.ex
+++ b/lib/trashy_web/controllers/event_controller.ex
@@ -55,21 +55,14 @@ defmodule TrashyWeb.EventController do
     end
 
     # Map each promotion's choices (if any) to the number of claims.
-    promotion_choice_claims = Enum.reduce(
-      Enum.concat(Map.values(participant_epps_claimed)), %{},
-      fn epp, acc ->
-        Map.update(
-          acc, epp.promotion,
-          %{ epp.choice => 1 },   # default: count this choice
-          fn choice_claims ->
-            Map.update(
-              choice_claims, epp.choice, 1,
-              fn count -> count + 1 end
-            )
-          end
-        )
-      end
-    )
+    promotion_choice_claims =
+      participant_epps_claimed
+      |> Map.values()
+      |> Enum.concat()  # Flatten into list of EventParticipantPromotions.
+      |> Enum.group_by(& &1.promotion, & &1.choice)
+      |> Map.new(fn { promotion, choices } ->
+        { promotion, Enum.frequencies(choices) }
+      end)
 
     render(conn, :show,
       event: event,

--- a/lib/trashy_web/controllers/event_controller.ex
+++ b/lib/trashy_web/controllers/event_controller.ex
@@ -35,10 +35,41 @@ defmodule TrashyWeb.EventController do
     event_checkin_url = url(conn, ~p"/event_participants/checkin/#{id}/#{event.code}")
     Logger.debug("Event checkin url #{event_checkin_url}")
 
+    promotions = for(
+      promotion <- Trashy.Promotions.list_promotions_for_cleanup(cleanup),
+      into: %{},
+      do: { promotion.id, promotion }
+    )
+
+    # Map each participant to a list of claimed promotions.
+    participant_promotions = for(
+      participant <- participants,
+      into: %{},
+      do: {
+        participant.id,
+        for(
+          epp <-
+          Trashy.Promotions.list_event_participant_promotions(participant.id),
+          epp.is_claimed,
+          do: promotions[epp.promotion_id]
+        )
+      }
+    )
+
+    # Map promotion ID to number of claims.
+    promotion_claims = Enum.frequencies(
+      for promotion <- List.flatten(Map.values(participant_promotions)) do
+        promotion.id
+      end
+    )
+
     render(conn, :show,
       event: event,
       cleanup: cleanup,
       event_participants: participants,
+      promotions: promotions,
+      participant_promotions: participant_promotions,
+      promotion_claims: promotion_claims,
       event_checkin_url: event_checkin_url
     )
   end

--- a/lib/trashy_web/controllers/event_controller.ex
+++ b/lib/trashy_web/controllers/event_controller.ex
@@ -37,29 +37,37 @@ defmodule TrashyWeb.EventController do
 
     promotions = for(
       promotion <- Trashy.Promotions.list_promotions_for_cleanup(cleanup),
-      into: %{},
-      do: { promotion.id, promotion }
-    )
+      into: %{}
+    ) do
+      { promotion.id, promotion }
+    end
 
     # Map each participant to a list of claimed promotions.
-    participant_promotions = for(
+    participant_epps_claimed = for(
       participant <- participants,
-      into: %{},
-      do: {
+      into: %{}
+    ) do
+      epps = Trashy.Promotions.list_event_participant_promotions(participant.id)
+      {
         participant.id,
-        for(
-          epp <-
-          Trashy.Promotions.list_event_participant_promotions(participant.id),
-          epp.is_claimed,
-          do: promotions[epp.promotion_id]
-        )
+        for epp <- epps, epp.is_claimed do epp end
       }
-    )
+    end
 
-    # Map promotion ID to number of claims.
-    promotion_claims = Enum.frequencies(
-      for promotion <- List.flatten(Map.values(participant_promotions)) do
-        promotion.id
+    # Map each promotion's choices (if any) to the number of claims.
+    promotion_choice_claims = Enum.reduce(
+      Enum.concat(Map.values(participant_epps_claimed)), %{},
+      fn epp, acc ->
+        Map.update(
+          acc, epp.promotion,
+          %{ epp.choice => 1 },   # default: count this choice
+          fn choice_claims ->
+            Map.update(
+              choice_claims, epp.choice, 1,
+              fn count -> count + 1 end
+            )
+          end
+        )
       end
     )
 
@@ -68,8 +76,8 @@ defmodule TrashyWeb.EventController do
       cleanup: cleanup,
       event_participants: participants,
       promotions: promotions,
-      participant_promotions: participant_promotions,
-      promotion_claims: promotion_claims,
+      participant_epps_claimed: participant_epps_claimed,
+      promotion_choice_claims: promotion_choice_claims,
       event_checkin_url: event_checkin_url
     )
   end

--- a/lib/trashy_web/controllers/event_html/show.html.heex
+++ b/lib/trashy_web/controllers/event_html/show.html.heex
@@ -39,6 +39,16 @@
   <:col :let={participant} label="Email"><%= participant.email %></:col>
   <:col :let={participant} label="First Name"><%= participant.first_name %></:col>
   <:col :let={participant} label="Last Name"><%= participant.last_name %></:col>
+  <:col :let={participant} label="Promos">
+    <%= Enum.join(
+      for promotion <- @participant_promotions[participant.id] do
+        promotion.icon
+      end
+    ) %>
+  </:col>
+  <:action :let={participant}>
+    <.link navigate={~p"/event_participants/certificate/#{participant.id}/#{participant.code}"}>Cert</.link>
+  </:action>
   <:action :let={participant}>
     <div class="sr-only">
       <.link navigate={~p"/organizer/events/#{@event.id}/event_participants/#{participant}"}>Show</.link>
@@ -50,6 +60,17 @@
       Delete
     </.link>
   </:action>
+</.table>
+
+<.header class="mt-10">
+  Promotions
+</.header>
+
+<.table id="promotions" rows={Map.values(@promotions)} row_click={&JS.navigate(~p"/organizer/promotions/#{&1.id}")}>
+  <:col :let={promotion} label="Icon"><%= promotion.icon %></:col>
+  <:col :let={promotion} label="Merchant"><%= promotion.merchant %></:col>
+  <:col :let={promotion} label="Details"><%= promotion.details %></:col>
+  <:col :let={promotion} label="Claims"><%= @promotion_claims[promotion.id] %></:col>
 </.table>
 
 <.header class="mt-10">

--- a/lib/trashy_web/controllers/event_html/show.html.heex
+++ b/lib/trashy_web/controllers/event_html/show.html.heex
@@ -18,6 +18,11 @@
 
 <.header class="mt-10">
   Check-in code
+  <:actions>
+    <.link href={@event_checkin_url}>
+      <.button>View check-in page</.button>
+    </.link>
+  </:actions>
 </.header>
 <img src={~p"/organizer/events/qr_code/#{Base.encode64(@event_checkin_url)}"} alt={@event_checkin_url}>
 

--- a/lib/trashy_web/controllers/event_html/show.html.heex
+++ b/lib/trashy_web/controllers/event_html/show.html.heex
@@ -68,17 +68,14 @@
 
 <.table
   id="promotions"
-  rows={Enum.concat(
-    for { promotion, choice_claims } <- @promotion_choice_claims do
-      for { choice, claims } <- choice_claims do
-        %{
-          promotion: promotion,
-          choice: choice,
-          claims: claims
-        }
-      end
-    end
-  )}
+  rows={for(
+    { promotion, choice_claims } <- @promotion_choice_claims,
+    { choice, claims } <- choice_claims
+  ) do %{
+    promotion: promotion,
+    choice: choice,
+    claims: claims
+  } end}
   row_click={&JS.navigate(~p"/organizer/promotions/#{&1.promotion.id}")}
 >
   <:col :let={r} label="Promotion">

--- a/lib/trashy_web/controllers/event_html/show.html.heex
+++ b/lib/trashy_web/controllers/event_html/show.html.heex
@@ -41,8 +41,8 @@
   <:col :let={participant} label="Last Name"><%= participant.last_name %></:col>
   <:col :let={participant} label="Promos">
     <%= Enum.join(
-      for promotion <- @participant_promotions[participant.id] do
-        promotion.icon
+      for epp <- @participant_epps_claimed[participant.id] do
+        epp.promotion.icon
       end
     ) %>
   </:col>
@@ -63,14 +63,34 @@
 </.table>
 
 <.header class="mt-10">
-  Promotions
+  Promotion Choices
 </.header>
 
-<.table id="promotions" rows={Map.values(@promotions)} row_click={&JS.navigate(~p"/organizer/promotions/#{&1.id}")}>
-  <:col :let={promotion} label="Icon"><%= promotion.icon %></:col>
-  <:col :let={promotion} label="Merchant"><%= promotion.merchant %></:col>
-  <:col :let={promotion} label="Details"><%= promotion.details %></:col>
-  <:col :let={promotion} label="Claims"><%= @promotion_claims[promotion.id] %></:col>
+<.table
+  id="promotions"
+  rows={Enum.concat(
+    for { promotion, choice_claims } <- @promotion_choice_claims do
+      for { choice, claims } <- choice_claims do
+        %{
+          promotion: promotion,
+          choice: choice,
+          claims: claims
+        }
+      end
+    end
+  )}
+  row_click={&JS.navigate(~p"/organizer/promotions/#{&1.promotion.id}")}
+>
+  <:col :let={r} label="Promotion">
+    <p><%= r.promotion.icon <> " " <> r.promotion.merchant %></p>
+    <p><%= r.promotion.details %></p>
+  </:col>
+  <:col :let={r} label="Choice">
+    <%= r.choice %>
+  </:col>
+  <:col :let={r} label="Claims">
+    <%= r.claims %>
+  </:col>
 </.table>
 
 <.header class="mt-10">

--- a/lib/trashy_web/controllers/promotion_html/promotion_form.html.heex
+++ b/lib/trashy_web/controllers/promotion_html/promotion_form.html.heex
@@ -7,6 +7,12 @@
   <.input field={f[:icon]} type="text" label="Icon (path to asset)" />
   <.input field={f[:cleanup_id]} type="select" label="Cleanup" prompt="Select a cleanup" options={@cleanups |> Enum.map(fn c -> {c.neighborhood, c.id} end)} />
   <.input field={f[:is_disabled]} type="checkbox" label="Disabled" />
+  <.input
+    field={f[:choices]}
+    type="textarea"
+    label="Menu choices (one per line)"
+    value={Enum.join(f[:choices].value(), "\n")}
+  />
   <:actions>
     <.button>Save Promotion</.button>
   </:actions>

--- a/lib/trashy_web/controllers/promotion_html/show.html.heex
+++ b/lib/trashy_web/controllers/promotion_html/show.html.heex
@@ -13,6 +13,11 @@
   <:item title="Icon"><%= @promotion.icon %></:item>
   <:item title="Cleanup"><%= @promotion.cleanup.neighborhood %></:item>
   <:item title="Disabled"><%= @promotion.is_disabled %></:item>
+  <:item title="Menu choices">
+    <ul>
+      <li :for={choice <- @promotion.choices}><%= choice %></li>
+    </ul>
+  </:item>
 </.list>
 
 <.back navigate={~p"/organizer/promotions"}>Back to promotions</.back>

--- a/lib/trashy_web/live/certificate_live.ex
+++ b/lib/trashy_web/live/certificate_live.ex
@@ -23,7 +23,7 @@ defmodule TrashyWeb.CertificateLive do
           <%= for epp <- @epps do %>
             <%
               promotion = epp.promotion
-              choices? = length(promotion.choices) > 0
+              choices? = (promotion.choices != [])
             %>
             <div class={"flex flex-row items-center space-x-2 bg-[#56506F] p-4 rounded " <> if epp.is_claimed do "opacity-25" else "" end}>
               <h1 class="basis-1/6 text-3xl">
@@ -176,16 +176,12 @@ defmodule TrashyWeb.CertificateLive do
         |> put_flash(:error, "This reward has already been redeemed.")
       }
     else
-      epp_chg = for key <- [
-        # Filter only to allowed keys.
-        "choice"
-      ], into: %{
-        "is_claimed" => true  # Always mark as claimed.
-      } do
-        { key, epp_chg[key] }
-      end
-      Trashy.Promotions.update_event_participant_promotion(
-        epp, epp_chg
+      { :ok, _ } = Trashy.Promotions.update_event_participant_promotion(
+        epp, Map.merge(
+          # Filter only to allowed keys.
+          Map.take(epp_chg, ["choice"]),
+          %{ "is_claimed" => true }   # Always mark as claimed.
+        )
       )
       epps = Trashy.Promotions.list_event_participant_promotions(participant_id)
       {

--- a/lib/trashy_web/live/certificate_live.ex
+++ b/lib/trashy_web/live/certificate_live.ex
@@ -6,6 +6,7 @@ defmodule TrashyWeb.CertificateLive do
     <%= if Enum.member?([1, 5, 10, 25, 50, 100, 200, 300, 500, 1000], @total_cleanup_count) do %>
       <div id="page-load" phx-hook="DisplayConfetti"></div>
     <% end %>
+    <.flash kind={:error} title="Error!" flash={@flash} />
     <div class="min-h-screen bg-gradient-to-bl from-[#3B2F64] to-[#2C293F]">
       <div class="flex-col lg:flex-row-reverse">
         <p class="p-4 text-white text-right">
@@ -20,7 +21,10 @@ defmodule TrashyWeb.CertificateLive do
         </div>
         <div class="flex flex-col space-y-4 m-8">
           <%= for epp <- @epps do %>
-            <% promotion = epp.promotion %>
+            <%
+              promotion = epp.promotion
+              choices? = length(promotion.choices) > 0
+            %>
             <div class={"flex flex-row items-center space-x-2 bg-[#56506F] p-4 rounded " <> if epp.is_claimed do "opacity-25" else "" end}>
               <h1 class="basis-1/6 text-3xl">
                 <%= promotion.icon %>
@@ -34,17 +38,35 @@ defmodule TrashyWeb.CertificateLive do
                 </h4>
               </div>
               <%= if epp.is_claimed do %>
+                <h3 class="basis-1/6 text-white text-center">
+                  <%= epp.choice || "Redeemed" %>
+                </h3>
               <% else %>
                 <label
-                  class={"btn basis-1/6 bg-white text-[#362D58] rounded normal-case border-none " <> if epp.is_claimed do "text-white" else "" end}
+                  class="btn basis-1/6 bg-white text-[#362D58] rounded normal-case border-none"
                   for={"claim_reward_modal_#{epp.id}"}
                 >
                   Redeem
                 </label>
               <% end %>
             </div>
-            <input type="checkbox" id={"claim_reward_modal_#{epp.id}"} class="modal-toggle" />
-            <div class="modal">
+            <input
+              type="checkbox"
+              id={"claim_reward_modal_#{epp.id}"}
+              class="modal-toggle"
+              phx-hook="ModalCheckboxHandlers"
+            />
+            <.form
+              :let={f}
+              for={to_form(
+                Trashy.Promotions.change_event_participant_promotion(epp),
+                as: "epp_chg"
+              )}
+              id={"claim_reward_form_#{epp.id}"}
+              class="modal"
+              phx-submit="claim_reward"
+            >
+              <.input type="hidden" field={f[:id]} />
               <div class="modal-box">
                 <div class="flex flex-col space-y-4">
                   <p class="text-center text-[#362D58]">Show this to the merchant.</p>
@@ -56,11 +78,27 @@ defmodule TrashyWeb.CertificateLive do
                       <h3 class="text-white">
                         <%= promotion.merchant %>
                       </h3>
-                      <h4 class="text-xs text-white">
-                        <%= promotion.details %>
-                      </h4>
+                      <%= if !choices? do %>
+                        <h4 class="text-xs text-white">
+                          <%= promotion.details %>
+                        </h4>
+                      <% else %>
+                      <% end %>
                     </div>
                   </div>
+                  <%= if choices? do %>
+                    <div class="flex flex-col bg-[#362D58] p-4 rounded">
+                      <.input
+                        type="select"
+                        field={f[:choice]}
+                        options={promotion.choices}
+                        label={promotion.details}
+                        prompt=""
+                        required
+                      />
+                    </div>
+                  <% else %>
+                  <% end %>
                   <div class="flex flex-row justify-between">
                     <label
                       class="btn basis-1/6 bg-white text-[#362D58] disabled:text-white rounded normal-case border-[#362D58]"
@@ -68,18 +106,16 @@ defmodule TrashyWeb.CertificateLive do
                     >
                       Cancel
                     </label>
-                    <label
+                    <.button
+                      type="submit"
                       class="btn basis-1/6 text-white bg-[#362D58] disabled:text-white rounded normal-case border-none"
-                      for={"claim_reward_modal_#{epp.id}"}
-                      phx-click="claim_reward"
-                      phx-value-epp_id={epp.id}
                     >
                       Redeem
-                    </label>
+                    </.button>
                   </div>
                 </div>
               </div>
-            </div>
+            </.form>
           <% end %>
         </div>
         <div class="text-center lg:text-left">
@@ -128,23 +164,38 @@ defmodule TrashyWeb.CertificateLive do
 
   def handle_event(
     "claim_reward",
-    %{"epp_id" => epp_id},
+    %{"epp_chg" => epp_chg},
     %{assigns: %{participant_id: participant_id}} = socket
   ) do
-    epp = Trashy.Promotions.get_event_participant_promotion!(epp_id)
+    epp = Trashy.Promotions.get_event_participant_promotion!(epp_chg["id"])
 
-    case epp.is_claimed do
-      true ->
-        {:noreply, assign(socket, success: false)}
-
-      false ->
-        Trashy.Promotions.update_event_participant_promotion(
-          epp, %{is_claimed: true}
-        )
-        epps = Trashy.Promotions.list_event_participant_promotions(
-          participant_id
-        )
-        {:noreply, assign(socket, success: true, epps: epps)}
+    if epp.is_claimed do
+      {
+        :noreply,
+        socket
+        |> put_flash(:error, "This reward has already been redeemed.")
+      }
+    else
+      epp_chg = for key <- [
+        # Filter only to allowed keys.
+        "choice"
+      ], into: %{
+        "is_claimed" => true  # Always mark as claimed.
+      } do
+        { key, epp_chg[key] }
+      end
+      Trashy.Promotions.update_event_participant_promotion(
+        epp, epp_chg
+      )
+      epps = Trashy.Promotions.list_event_participant_promotions(participant_id)
+      {
+        :noreply,
+        socket
+        |> assign(epps: epps)
+        |> push_event("js:modal:#claim_reward_modal_#{epp.id}", %{
+          open: false   # Close the modal.
+        })
+      }
     end
   end
 end

--- a/lib/trashy_web/live/certificate_live.ex
+++ b/lib/trashy_web/live/certificate_live.ex
@@ -19,61 +19,60 @@ defmodule TrashyWeb.CertificateLive do
           </p>
         </div>
         <div class="flex flex-col space-y-4 m-8">
-          <%= for promotion <- @promotions do %>
-            <div class={"flex flex-row items-center space-x-2 bg-[#56506F] p-4 rounded " <> if promotion.is_claimed do "opacity-25" else "" end}>
+          <%= for epp <- @epps do %>
+            <% promotion = epp.promotion %>
+            <div class={"flex flex-row items-center space-x-2 bg-[#56506F] p-4 rounded " <> if epp.is_claimed do "opacity-25" else "" end}>
               <h1 class="basis-1/6 text-3xl">
-                <%= promotion.promotion.icon %>
+                <%= promotion.icon %>
               </h1>
               <div class="basis-2/3">
                 <h3 class="text-white">
-                  <%= promotion.promotion.merchant %>
+                  <%= promotion.merchant %>
                 </h3>
                 <h4 class="text-xs text-white">
-                  <%= promotion.promotion.details %>
+                  <%= promotion.details %>
                 </h4>
               </div>
-              <%= if promotion.is_claimed do %>
+              <%= if epp.is_claimed do %>
               <% else %>
                 <label
-                  class={"btn basis-1/6 bg-white text-[#362D58] rounded normal-case border-none "<> if promotion.is_claimed do "text-white" else "" end}
-                  for={"claim_reward_modal_#{promotion.id}"}
+                  class={"btn basis-1/6 bg-white text-[#362D58] rounded normal-case border-none " <> if epp.is_claimed do "text-white" else "" end}
+                  for={"claim_reward_modal_#{epp.id}"}
                 >
                   Redeem
                 </label>
               <% end %>
             </div>
-            <input type="checkbox" id={"claim_reward_modal_#{promotion.id}"} class="modal-toggle" />
+            <input type="checkbox" id={"claim_reward_modal_#{epp.id}"} class="modal-toggle" />
             <div class="modal">
               <div class="modal-box">
-                <div class="flex flex-col">
-                  <div class="m-auto py-4">
-                    <p class="text-[#362D58]">Show this to the merchant.</p>
-                  </div>
+                <div class="flex flex-col space-y-4">
+                  <p class="text-center text-[#362D58]">Show this to the merchant.</p>
                   <div class="flex flex-row items-center bg-[#362D58] space-x-2 p-4 rounded" }>
                     <h1 class="basis-1/6 text-3xl p-2 rounded">
-                      <%= promotion.promotion.icon %>
+                      <%= promotion.icon %>
                     </h1>
                     <div class="basis-2/3">
                       <h3 class="text-white">
-                        <%= promotion.promotion.merchant %>
+                        <%= promotion.merchant %>
                       </h3>
                       <h4 class="text-xs text-white">
-                        <%= promotion.promotion.details %>
+                        <%= promotion.details %>
                       </h4>
                     </div>
                   </div>
-                  <div class="flex flex-row justify-between py-6">
+                  <div class="flex flex-row justify-between">
                     <label
                       class="btn basis-1/6 bg-white text-[#362D58] disabled:text-white rounded normal-case border-[#362D58]"
-                      for={"claim_reward_modal_#{promotion.id}"}
+                      for={"claim_reward_modal_#{epp.id}"}
                     >
                       Cancel
                     </label>
                     <label
                       class="btn basis-1/6 text-white bg-[#362D58] disabled:text-white rounded normal-case border-none"
-                      for={"claim_reward_modal_#{promotion.id}"}
+                      for={"claim_reward_modal_#{epp.id}"}
                       phx-click="claim_reward"
-                      phx-value-promotion_id={promotion.id}
+                      phx-value-epp_id={epp.id}
                     >
                       Redeem
                     </label>
@@ -106,11 +105,14 @@ defmodule TrashyWeb.CertificateLive do
     case code == participant.code do
       true ->
         event = Trashy.Events.get_event!(participant.event_id)
+        epps = Trashy.Promotions.list_event_participant_promotions(
+          participant_id
+        )
 
         {:ok,
          assign(socket,
            participant_id: participant_id,
-           promotions: Trashy.Promotions.list_event_participant_promotions(participant_id),
+           epps: epps,
            participant: participant,
            total_cleanup_count: Trashy.Events.get_total_participant_cleanup_count(participant),
            local_cleanup_count:
@@ -125,20 +127,24 @@ defmodule TrashyWeb.CertificateLive do
   end
 
   def handle_event(
-        "claim_reward",
-        %{"promotion_id" => promotion_id},
-        %{assigns: %{participant_id: participant_id}} = socket
-      ) do
-    promotion = Trashy.Promotions.get_event_participant_promotion!(promotion_id)
+    "claim_reward",
+    %{"epp_id" => epp_id},
+    %{assigns: %{participant_id: participant_id}} = socket
+  ) do
+    epp = Trashy.Promotions.get_event_participant_promotion!(epp_id)
 
-    case promotion.is_claimed do
+    case epp.is_claimed do
       true ->
         {:noreply, assign(socket, success: false)}
 
       false ->
-        Trashy.Promotions.update_event_participant_promotion(promotion, %{is_claimed: true})
-        promotions = Trashy.Promotions.list_event_participant_promotions(participant_id)
-        {:noreply, assign(socket, success: true, promotions: promotions)}
+        Trashy.Promotions.update_event_participant_promotion(
+          epp, %{is_claimed: true}
+        )
+        epps = Trashy.Promotions.list_event_participant_promotions(
+          participant_id
+        )
+        {:noreply, assign(socket, success: true, epps: epps)}
     end
   end
 end

--- a/priv/repo/migrations/20260407000100_add_promotion_choices.exs
+++ b/priv/repo/migrations/20260407000100_add_promotion_choices.exs
@@ -1,0 +1,9 @@
+defmodule Trashy.Repo.Migrations.AddPromotionChoices do
+  use Ecto.Migration
+
+  def change do
+    alter table(:promotions) do
+      add(:choices, {:array, :string}, default: [], null: [])
+    end
+  end
+end

--- a/priv/repo/migrations/20260407000101_add_event_participant_promotions_choice.exs
+++ b/priv/repo/migrations/20260407000101_add_event_participant_promotions_choice.exs
@@ -1,0 +1,9 @@
+defmodule Trashy.Repo.Migrations.AddEventParticipantPromotionsChoice do
+  use Ecto.Migration
+
+  def change do
+    alter table(:event_participant_promotions) do
+      add(:choice, :string, default: "", null: "")
+    end
+  end
+end


### PR DESCRIPTION
As a trash pickup captain, it would be useful to quickly understand each event's participant promotion claims (i.e., if the participant pressed "Redeem" on the promotion).

Meanwhile, various trash pickups have their participants order brunch, etc. from a menu:
- #75

---

To implement this menu, each `Promotion` now has an optional sequence of `choices`. The promotion-editing page has now gained an optional `textarea` input, whose lines are split into the choices.

<img width="698" height="586" alt="edit promotion with choices" src="https://github.com/user-attachments/assets/20f268da-0675-4c7b-9a43-674fa0466316" />

---

Next, each `EventParticipantPromotion` now has a `choice` string field. On the participant's certificate page, the modal for redeeming a promotion with `choices` now displays a (required) `select` input containing those choices. The selected option is recorded as the `choice`.

<img width="480" height="182" alt="redeem promotion modal - selection required" src="https://github.com/user-attachments/assets/4f9e1be1-8a10-446b-97cf-5936bb3f7bb2" />
<img width="525" height="364" alt="redeem promotion modal" src="https://github.com/user-attachments/assets/3a11377b-7056-4894-9251-84a958a3b182" />
<img width="351" height="197" alt="redeemed promotions" src="https://github.com/user-attachments/assets/48038f00-fa31-4c4e-b893-aedb20caa35c" />

---

Finally, this change adds a "Promotion Choices" table to the organizer's event page. Each row shows the promotion's information, plus a count of each choice selected by the participant. The event's participant list gains a "Promos" column, which displays an icon for each participant's claimed promotions.

<img width="693" height="788" alt="organizer event tables" src="https://github.com/user-attachments/assets/3dda962b-4cb2-4a4b-a059-ea514a65f564" />

---

While we are here, some small bonus events-page tweaks:
- Add a "View check-in page" button to quickly jump to the check-in page.
- Add a "Cert" button for each participant, to quickly view their "certificate" page.
- Remove a dead comment in `lib/trashy/events.ex`.

